### PR TITLE
Declare beforeCommit plugin to control commits

### DIFF
--- a/packages/eventive/src/EventivePlugin.ts
+++ b/packages/eventive/src/EventivePlugin.ts
@@ -4,10 +4,6 @@ export type EventivePlugin<
   DomainEvent extends BaseDomainEvent<string, {}>,
   State extends {}
 > = {
-  beforeCommit?(args: {
-    event: DomainEvent;
-    entity: BaseEntity<State>;
-    abortCommit: () => void;
-  }): void;
+  beforeCommit?(args: { event: DomainEvent; entity: BaseEntity<State> }): void;
   onCommitted?(args: { event: DomainEvent; entity: BaseEntity<State> }): void;
 };

--- a/packages/eventive/src/EventivePlugin.ts
+++ b/packages/eventive/src/EventivePlugin.ts
@@ -4,5 +4,10 @@ export type EventivePlugin<
   DomainEvent extends BaseDomainEvent<string, {}>,
   State extends {}
 > = {
+  beforeCommit?(args: {
+    event: DomainEvent;
+    entity: BaseEntity<State>;
+    abortCommit: () => void;
+  }): void;
   onCommitted?(args: { event: DomainEvent; entity: BaseEntity<State> }): void;
 };

--- a/packages/eventive/src/eventive.test.ts
+++ b/packages/eventive/src/eventive.test.ts
@@ -8,7 +8,8 @@ import type { BaseDomainEvent, BaseReducer } from "./util-types";
 
 type MyDomainEvent =
   | BaseDomainEvent<"init", { datetime: string }>
-  | BaseDomainEvent<"update", { datetime: string }>;
+  | BaseDomainEvent<"update", { datetime: string }>
+  | BaseDomainEvent<"updateToAbort", { datetime: string }>;
 
 type MyState = {
   createdDatetime: string;
@@ -25,6 +26,11 @@ const reducer: MyReducer = (prevState, event) => {
         updatedDatetime: event.body.datetime,
       };
     case "update":
+      return {
+        ...prevState,
+        updatedDatetime: event.body.datetime,
+      };
+    case "updateToAbort":
       return {
         ...prevState,
         updatedDatetime: event.body.datetime,
@@ -315,7 +321,7 @@ describe("eventive()", () => {
       event: MyDomainEvent;
       abortCommit: () => void;
     }) => {
-      if (event.eventName === "update") {
+      if (event.eventName === "updateToAbort") {
         abortCommit();
       }
     };
@@ -344,6 +350,96 @@ describe("eventive()", () => {
 
     await delay(100);
 
+    const updateAbortedDatetime = new Date().toISOString();
+
+    const { commit: commitUpdateToAbort } = myRepository.dispatch({
+      entity,
+      eventName: "updateToAbort",
+      eventBody: {
+        datetime: updateAbortedDatetime,
+      },
+    });
+
+    await commitUpdateToAbort();
+
+    const updateAbortedEntity = await myRepository.findOne({
+      entityId: entity.entityId,
+    });
+
+    if (!updateAbortedEntity) {
+      throw new Error("updateAbortedEntity not found");
+    }
+
+    expect(updateAbortedEntity.state.updatedDatetime).toBe(initDatetime);
+    expect(updateAbortedEntity.state.updatedDatetime).not.toBe(
+      updateAbortedDatetime
+    );
+  });
+
+  test("beforeCommit plugin does not affect other commits", async () => {
+    const blockCommitPlugin = ({
+      event,
+      abortCommit,
+    }: {
+      event: MyDomainEvent;
+      abortCommit: () => void;
+    }) => {
+      if (event.eventName === "updateToAbort") {
+        abortCommit();
+      }
+    };
+
+    const myRepository = eventive({
+      db,
+      entityName: "MyEntity2",
+      reducer,
+      plugins: [
+        {
+          beforeCommit: blockCommitPlugin,
+        },
+      ],
+    });
+
+    const initDatetime = new Date().toISOString();
+
+    const { entity, commit: commitCreate } = myRepository.create({
+      eventName: "init",
+      eventBody: {
+        datetime: initDatetime,
+      },
+    });
+
+    await commitCreate();
+
+    await delay(100);
+
+    const updateAbortedDatetime = new Date().toISOString();
+
+    const { commit: commitUpdateToAbort } = myRepository.dispatch({
+      entity,
+      eventName: "updateToAbort",
+      eventBody: {
+        datetime: updateAbortedDatetime,
+      },
+    });
+
+    await commitUpdateToAbort();
+
+    const updateAbortedEntity = await myRepository.findOne({
+      entityId: entity.entityId,
+    });
+
+    if (!updateAbortedEntity) {
+      throw new Error("targetEntity not found");
+    }
+
+    expect(updateAbortedEntity.state.updatedDatetime).toBe(initDatetime);
+    expect(updateAbortedEntity.state.updatedDatetime).not.toBe(
+      updateAbortedDatetime
+    );
+
+    await delay(100);
+
     const updatedDatetime = new Date().toISOString();
 
     const { commit: commitUpdate } = myRepository.dispatch({
@@ -356,16 +452,16 @@ describe("eventive()", () => {
 
     await commitUpdate();
 
-    const targetEntity = await myRepository.findOne({
+    const updatedEntity = await myRepository.findOne({
       entityId: entity.entityId,
     });
 
-    if (!targetEntity) {
-      throw new Error("targetEntity not found");
+    if (!updatedEntity) {
+      throw new Error("updatedEntity not found");
     }
 
-    expect(targetEntity.updatedAt).toBe(initDatetime);
-    expect(targetEntity.updatedAt).not.toBe(updatedDatetime);
+    expect(updatedEntity.state.updatedDatetime).not.toBe(initDatetime);
+    expect(updatedEntity.state.updatedDatetime).toBe(updatedDatetime);
   });
 
   afterAll(async () => {

--- a/packages/eventive/src/eventive.ts
+++ b/packages/eventive/src/eventive.ts
@@ -101,6 +101,8 @@ export function eventive<
 
   const plugins = options.plugins ?? [];
 
+  let shouldAbort = false;
+
   const commitEvent = async ({
     event,
     entity,
@@ -108,8 +110,6 @@ export function eventive<
     event: DomainEvent;
     entity: BaseEntity<State>;
   }) => {
-    let shouldAbort = false;
-
     const abortCommit = () => {
       shouldAbort = true;
     };

--- a/packages/eventive/src/eventive.ts
+++ b/packages/eventive/src/eventive.ts
@@ -123,6 +123,7 @@ export function eventive<
     }
 
     if (shouldAbort) {
+      shouldAbort = false;
       return;
     }
 

--- a/packages/eventive/src/eventive.ts
+++ b/packages/eventive/src/eventive.ts
@@ -108,6 +108,24 @@ export function eventive<
     event: DomainEvent;
     entity: BaseEntity<State>;
   }) => {
+    let shouldAbort = false;
+
+    const abortCommit = () => {
+      shouldAbort = true;
+    };
+
+    for (const plugin of plugins) {
+      plugin.beforeCommit?.({
+        event: options.mapper?.(event) ?? event,
+        entity,
+        abortCommit,
+      });
+    }
+
+    if (shouldAbort) {
+      return;
+    }
+
     const eventDocument = event as OptionalUnlessRequiredId<DomainEvent>;
 
     await eventsCollection.insertOne(eventDocument);

--- a/packages/eventive/src/eventive.ts
+++ b/packages/eventive/src/eventive.ts
@@ -101,8 +101,6 @@ export function eventive<
 
   const plugins = options.plugins ?? [];
 
-  let shouldAbort = false;
-
   const commitEvent = async ({
     event,
     entity,
@@ -110,21 +108,11 @@ export function eventive<
     event: DomainEvent;
     entity: BaseEntity<State>;
   }) => {
-    const abortCommit = () => {
-      shouldAbort = true;
-    };
-
     for (const plugin of plugins) {
       plugin.beforeCommit?.({
         event: options.mapper?.(event) ?? event,
         entity,
-        abortCommit,
       });
-    }
-
-    if (shouldAbort) {
-      shouldAbort = false;
-      return;
     }
 
     const eventDocument = event as OptionalUnlessRequiredId<DomainEvent>;


### PR DESCRIPTION
Hello,

I've implemented a `beforeCommit` function to ensure data integrity during command operations like create or update in our commit process. This function facilitates writing to the database only after successful validation.

The `beforeCommit` plugin operates as follows: it validates the contents of an event body before proceeding with the commit. This is demonstrated in the code snippet below:

```typescript
eventive({
    db,
    entityName: “foo",
    reducer: fooReducer,
    plugins: [
      {
        beforeCommit({ event, entity, abortCommit }) {
          if (event.body.fooValue.includes(“invalidValue”)) {
            abortCommit()
          }
        },
      },
    ],
  })
```

In this setup, if the `event.body.fooValue` contains the string `"invalidValue"`, the commit is aborted to prevent the entry of invalid data into the database. This ensures that only validated and correct data is committed.