### PR TITLE
feat: Throw error when querySnapshots is called without useSnapshot flag

### DIFF
--- a/packages/eventive/src/eventive.test.ts
+++ b/packages/eventive/src/eventive.test.ts
@@ -349,8 +349,36 @@ describe("eventive()", () => {
     expect(entity2.entityId).toEqual(result[1].entityId);
   });
 
+  test("if useSnapshot is not declared, querySnapshot() throw error", async () => {
+    const myRepository = eventive({
+      db,
+      entityName: "MyEntity2",
+      reducer,
+      useSnapshot: false,
+    });
+
+    const currentDatetime = new Date().toISOString();
+
+    const { commit } = myRepository.create({
+      eventName: "init",
+      eventBody: {
+        datetime: currentDatetime,
+      },
+    });
+
+    await commit();
+
+    await expect(
+      myRepository.querySnapshots({
+        filter: {
+          "state.createdDatetime": currentDatetime,
+        },
+      })
+    ).rejects.toThrow();
+  });
+
   test("plugin interface: onCommitted", async () => {
-    const onCommit = vi.fn(() => {});
+    const onCommit = vi.fn(() => { });
 
     const myRepository = eventive({
       db,
@@ -396,7 +424,7 @@ describe("eventive()", () => {
   });
 
   test("plugin interface: beforeCommit", async () => {
-    const beforeCommitHook = vi.fn(() => {});
+    const beforeCommitHook = vi.fn(() => { });
 
     const myRepository = eventive({
       db,

--- a/packages/eventive/src/eventive.ts
+++ b/packages/eventive/src/eventive.ts
@@ -110,7 +110,7 @@ export function eventive<
   );
   const snapshotsCollection = options.db.collection<BaseEntity<State>>(
     options.dbSnapshotsCollectionName ??
-      `${snakeCase(options.entityName)}_snapshots`
+    `${snakeCase(options.entityName)}_snapshots`
   );
 
   const plugins = options.plugins ?? [];
@@ -260,6 +260,12 @@ export function eventive<
     filter,
     limit,
   }) => {
+    if (!options.useSnapshot) {
+      throw new Error(
+        "useSnapshot is falsy. Please set useSnapshot to true explicitly."
+      );
+    }
+
     const cursor = snapshotsCollection.find({
       ...filter,
     });


### PR DESCRIPTION
 To use useSnapshot flag explicitly