### PR TITLE
fix: use prepack for embedded docs generation

### DIFF
--- a/.changeset/fix-prepack-docs.md
+++ b/.changeset/fix-prepack-docs.md
@@ -1,0 +1,5 @@
+---
+"ventyd": patch
+---
+
+Use prepack instead of postbuild for embedded docs generation to ensure dist/docs/ is included in the published package

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "build": "tsdown",
     "build:docs": "npm run build -w docs && tsx scripts/generate-docs.ts",
-    "postbuild": "tsx scripts/generate-docs.ts",
+    "prepack": "tsx scripts/generate-docs.ts",
     "format": "biome check --write --unsafe .",
     "release": "changeset publish",
     "test": "vitest run ./test",


### PR DESCRIPTION
## Summary
- Replace `postbuild` with `prepack` script for `tsx scripts/generate-docs.ts`
- `postbuild` runs after `tsdown` but the docs site build output (`docs/build/client/llms/`) may not exist yet, resulting in empty `dist/docs/`
- `prepack` runs at publish time (Mastra pattern), ensuring docs are generated when the build output is available

## Test plan
- [ ] `npm run build:docs` generates `dist/docs/*.md` (13 files)
- [ ] `npm pack --dry-run` shows `dist/docs/` files included

🤖 Generated with [Claude Code](https://claude.com/claude-code)