### PR TITLE
fix: skip docs generation when build output missing

### DIFF
--- a/.changeset/fix-prepack-skip.md
+++ b/.changeset/fix-prepack-skip.md
@@ -1,0 +1,5 @@
+---
+"ventyd": patch
+---
+
+Skip embedded docs generation gracefully when docs build output is not available

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -86,10 +86,10 @@ async function main() {
   try {
     files = await readdir(DOCS_BUILD);
   } catch {
-    console.error(
-      "docs/build/client/llms/ not found. Run `npm run build` in docs/ first.",
+    console.warn(
+      "Skipping docs generation: docs/build/client/llms/ not found. Run `npm run build:docs` to generate embedded docs.",
     );
-    process.exit(1);
+    return;
   }
 
   // Filter to only data-less resource files (the actual markdown content)


### PR DESCRIPTION
## Summary
- Fix CI release failure: `prepack` script (`tsx scripts/generate-docs.ts`) was failing with exit code 1 when `docs/build/client/llms/` doesn't exist
- Change from `process.exit(1)` to `console.warn()` + early return so publishing succeeds even without docs build
- Docs can still be generated explicitly via `npm run build:docs`

Fixes https://github.com/daangn/ventyd/actions/runs/24237153402/job/70762517585

## Test plan
- [ ] `npm run prepack` succeeds without docs build output (warns and skips)
- [ ] `npm run build:docs` still generates `dist/docs/*.md` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)