### PR TITLE
fix: add docs build to release CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Build Docs
+        run: yarn build:docs
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- Published ventyd@1.20.2 is missing `dist/docs/*.md` (74 files vs expected 87)
- Root cause: CI release workflow runs `yarn build` (tsdown) then `yarn release` (changeset publish → npm publish → prepack)
- `prepack` runs `generate-docs.ts` but `docs/build/client/llms/` doesn't exist in CI — script skips gracefully
- Fix: add `yarn build:docs` step between `yarn build` and publish to build docs site + generate embedded markdown

## Test plan
- [ ] CI release workflow succeeds
- [ ] Published package contains `dist/docs/*.md` (87 total files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)