### PR TITLE
chore: trigger release with embedded docs

### DIFF
--- a/.changeset/release-embedded-docs.md
+++ b/.changeset/release-embedded-docs.md
@@ -1,0 +1,5 @@
+---
+"ventyd": patch
+---
+
+Include embedded docs (dist/docs/*.md) in published package via CI docs build step


### PR DESCRIPTION
## Summary
Add changeset to trigger a new patch release that includes `dist/docs/*.md` in the published npm package. The previous release (1.20.2) was missing these files because the CI workflow didn't build docs before publishing. That's now fixed (#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)