### PR TITLE
fix(docs): fix broken internal links across documentation pages

### DIFF
--- a/docs/content/docs/error-handling.mdx
+++ b/docs/content/docs/error-handling.mdx
@@ -633,6 +633,5 @@ describe('Error Handling', () => {
 
 ## Related Documentation
 
-- [Best Practices](/docs/best-practices)
-- [Creating Custom Plugins](/docs/plugins/creating-plugins)
-- [Testing Guide](/docs/guides/testing)
+- [Creating Custom Plugins](/docs/plugins)
+- [Testing Guide](/docs/testing)

--- a/docs/content/docs/event-granularity.mdx
+++ b/docs/content/docs/event-granularity.mdx
@@ -542,6 +542,5 @@ dispatch("inventory:updated", { productId, quantity });
 
 ## Related Documentation
 
-- [Event Naming](/docs/guides/event-naming)
-- [Best Practices](/docs/best-practices)
-- [Creating Custom Plugins](/docs/plugins/creating-plugins)
+- [Event Naming](/docs/event-naming)
+- [Creating Custom Plugins](/docs/plugins)

--- a/docs/content/docs/event-naming.mdx
+++ b/docs/content/docs/event-naming.mdx
@@ -469,6 +469,5 @@ describe('Event Naming Conventions', () => {
 
 ## Related Documentation
 
-- [Event Granularity](/docs/guides/event-granularity)
-- [Best Practices](/docs/best-practices)
-- [Event Versioning](/docs/guides/event-versioning)
+- [Event Granularity](/docs/event-granularity)
+- [Event Versioning](/docs/event-versioning)

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -15,7 +15,7 @@ Traditional applications only store the current state of your data. Ventyd takes
   <Card
     title="Type-Safe"
     description="Full TypeScript support with comprehensive type inference. Catch errors at compile time."
-    href="/docs/getting-started"
+    href="/docs/quick-start"
   />
   <Card
     title="Flexible Schema"
@@ -52,7 +52,7 @@ Ventyd follows a simple pattern:
   <Card
     title="Getting Started"
     description="Installation and quick start"
-    href="/docs/getting-started"
+    href="/docs/quick-start"
   />
   <Card
     title="Core Concepts"

--- a/docs/content/docs/testing.mdx
+++ b/docs/content/docs/testing.mdx
@@ -593,5 +593,4 @@ Focus on testing behavior through the entity interface:
 ## Related Documentation
 
 - [Error Handling](/docs/error-handling)
-- [Best Practices](/docs/best-practices)
 - [Plugins](/docs/plugins)


### PR DESCRIPTION
## Summary

- Fixed 9 broken internal links across 5 documentation files
- Corrected `/docs/guides/*` paths (the `guides/` subdirectory doesn't exist) to their actual paths
- Fixed `/docs/plugins/creating-plugins` → `/docs/plugins`
- Fixed `/docs/getting-started` → `/docs/quick-start` in `index.mdx`
- Removed links to the non-existent `/docs/best-practices` page

## Test plan

- [ ] Verify all updated links resolve correctly in the docs site
- [ ] Check no other broken links remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)